### PR TITLE
Add content for data scenario 3.

### DIFF
--- a/content/exercises/data-scenarios/03-needs-reprojection/README.md
+++ b/content/exercises/data-scenarios/03-needs-reprojection/README.md
@@ -1,5 +1,10 @@
 # Data Scenario: Data file needs reprojection
 
-You've developed an analysis pipeline which expects input data in `EPSG:3413`
-projection. However, the scientist you're working with to provide input data sends you a
-file in an unexpected projection.
+A colleague has sent you a CSV file containing the locations of potential field
+study sites in Greenland. The CSV provides coordinates in latitude and longitude
+(EPSG:4326 / WGS84) but your site sutibility analysis code expects coordinates
+in NSIDC Polar Stereogrpahic North (EPSG:3413). Furthermore, your code expects
+that the potential sites be provided as a GeoPackage (`.gpkg) file.
+
+Reproject `datafile.csv` from `EPSG:4326` to `EPSG:3413` and convert the format
+to GeoPackage.

--- a/content/exercises/data-scenarios/03-needs-reprojection/README.md
+++ b/content/exercises/data-scenarios/03-needs-reprojection/README.md
@@ -4,7 +4,7 @@ A colleague has sent you a CSV file containing the locations of potential field
 study sites in Greenland. The CSV provides coordinates in latitude and longitude
 (EPSG:4326 / WGS84) but your site suitability analysis code expects coordinates
 in NSIDC Polar Stereogrpahic North (EPSG:3413). Furthermore, your code expects
-that the potential sites be provided as a GeoPackage (`.gpkg) file.
+that the potential sites be provided as a GeoPackage (`.gpkg`) file.
 
 Reproject `datafile.csv` from `EPSG:4326` to `EPSG:3413` and convert the format
 to GeoPackage.

--- a/content/exercises/data-scenarios/03-needs-reprojection/README.md
+++ b/content/exercises/data-scenarios/03-needs-reprojection/README.md
@@ -2,7 +2,7 @@
 
 A colleague has sent you a CSV file containing the locations of potential field
 study sites in Greenland. The CSV provides coordinates in latitude and longitude
-(EPSG:4326 / WGS84) but your site sutibility analysis code expects coordinates
+(EPSG:4326 / WGS84) but your site suitability analysis code expects coordinates
 in NSIDC Polar Stereogrpahic North (EPSG:3413). Furthermore, your code expects
 that the potential sites be provided as a GeoPackage (`.gpkg) file.
 

--- a/content/exercises/data-scenarios/03-needs-reprojection/datafile.csv
+++ b/content/exercises/data-scenarios/03-needs-reprojection/datafile.csv
@@ -1,0 +1,5 @@
+id,longitude,latitude,description
+1,-45.214,62.259,"very cold"
+2,-49.525,70.915,"nice view"
+3,-26.532,71.728,"desirable geology"
+4,-44.413,80.938,"near existing study site"

--- a/content/exercises/data-scenarios/03-needs-reprojection/solution.sh
+++ b/content/exercises/data-scenarios/03-needs-reprojection/solution.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ogr2ogr datafile_3413.gpkg datafile.csv -a_srs "EPSG:4326" -t_srs "EPSG:3413" -oo X_POSSIBLE_NAMES=lon* -oo Y_POSSIBLE_NAMES=lat*

--- a/content/exercises/data-scenarios/03-needs-reprojection/solution.sh
+++ b/content/exercises/data-scenarios/03-needs-reprojection/solution.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-ogr2ogr datafile_3413.gpkg datafile.csv -a_srs "EPSG:4326" -t_srs "EPSG:3413" -oo X_POSSIBLE_NAMES=lon* -oo Y_POSSIBLE_NAMES=lat*
+# ogr2ogr: https://gdal.org/programs/ogr2ogr.html
+ogr2ogr \
+    datafile_3413.gpkg \
+    datafile.csv \
+    -a_srs "EPSG:4326" \
+    -t_srs "EPSG:3413" \
+    -oo X_POSSIBLE_NAMES=lon* \
+    -oo Y_POSSIBLE_NAMES=lat*


### PR DESCRIPTION
Involves reprojection of point data in a CSV file.

On face, this exercise seems straightforward, but users will need to pass open options to `ogr2ogr` so that the csv driver knows which fields are to be used for coordinates.

We could also add another scenario to this that involves reprojecting raster data. I thought about that for a while, and I think there could be a discussion around common interpolation techniques for raster data (e.g., choose `nearest` or `mode` interpolation for categorical data, and something like `bilinear` for continuous data. I'm not sure exactly what the best way to demonstrate this concept as an exercise yet, however. 